### PR TITLE
Provide a source config

### DIFF
--- a/source/config.go
+++ b/source/config.go
@@ -1,0 +1,62 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/conduitio-labs/conduit-connector-hubspot/config"
+)
+
+// ConfigKeyPollingPeriod is a config name for a polling period.
+const ConfigKeyPollingPeriod = "pollingPeriod"
+
+// defaultPollingPeriod is a default PollingPeriod's value used if the PollingPeriod field is empty.
+const defaultPollingPeriod = time.Second * 5
+
+// Config holds source-specific configurable values.
+type Config struct {
+	config.Config
+
+	// PollingPeriod is the duration that defines a period of polling
+	// new items if CDC is not available for a resource.
+	PollingPeriod time.Duration `key:"pollingPeriod"`
+}
+
+// ParseConfig seeks to parse a provided map[string]string into a Config struct.
+func ParseConfig(cfg map[string]string) (Config, error) {
+	commonConfig, err := config.Parse(cfg)
+	if err != nil {
+		return Config{}, fmt.Errorf("parse common config: %w", err)
+	}
+
+	sourceConfig := Config{
+		Config:        commonConfig,
+		PollingPeriod: defaultPollingPeriod,
+	}
+
+	// parse pollingPeriod if it's not empty.
+	if pollingPeriodStr := cfg[ConfigKeyPollingPeriod]; pollingPeriodStr != "" {
+		pollingPeriod, err := time.ParseDuration(pollingPeriodStr)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse polling period: %w", err)
+		}
+
+		sourceConfig.PollingPeriod = pollingPeriod
+	}
+
+	return sourceConfig, nil
+}

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -36,7 +36,24 @@ func TestParseConfig(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "success",
+			name: "success_required_and_default_values",
+			args: args{
+				cfg: map[string]string{
+					config.KeyAccessToken: "access_token",
+					config.KeyResource:    "contacts",
+				},
+			},
+			want: Config{
+				Config: config.Config{
+					AccessToken: "access_token",
+					Resource:    "contacts",
+				},
+				PollingPeriod: defaultPollingPeriod,
+			},
+			wantErr: false,
+		},
+		{
+			name: "success_required_and_custom_values",
 			args: args{
 				cfg: map[string]string{
 					config.KeyAccessToken:  "access_token",

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -1,0 +1,99 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/conduitio-labs/conduit-connector-hubspot/config"
+)
+
+func TestParseConfig(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		cfg map[string]string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    Config
+		wantErr bool
+	}{
+		{
+			name: "success",
+			args: args{
+				cfg: map[string]string{
+					config.KeyAccessToken:  "access_token",
+					config.KeyResource:     "contacts",
+					ConfigKeyPollingPeriod: "10s",
+				},
+			},
+			want: Config{
+				Config: config.Config{
+					AccessToken: "access_token",
+					Resource:    "contacts",
+				},
+				PollingPeriod: time.Second * 10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail_missing_required_common_config_value",
+			args: args{
+				cfg: map[string]string{
+					config.KeyResource:     "contacts",
+					ConfigKeyPollingPeriod: "10s",
+				},
+			},
+			want:    Config{},
+			wantErr: true,
+		},
+		{
+			name: "fail_invalid_polling_period",
+			args: args{
+				cfg: map[string]string{
+					config.KeyAccessToken:  "access_token",
+					config.KeyResource:     "contacts",
+					ConfigKeyPollingPeriod: "ten seconds",
+				},
+			},
+			want:    Config{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseConfig(tt.args.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseConfig() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR seeks to provide a source config with one field, `PollingPeriod`, so far.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-hubspot/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
