### PR TITLE
Update CDC and fix `bufferSize` and HubSpot limit functionality 

### DIFF
--- a/hubspot/list.go
+++ b/hubspot/list.go
@@ -225,7 +225,7 @@ func (c *Client) List(ctx context.Context, resource string, opts *ListOptions) (
 
 	var resp ListResponse
 	if err := c.do(req, &resp); err != nil {
-		return nil, fmt.Errorf("do request: %w", err)
+		return nil, fmt.Errorf("execute request: %w", err)
 	}
 
 	return &resp, nil
@@ -241,7 +241,7 @@ func (c *Client) ListByNextLink(ctx context.Context, nextLink string) (*ListResp
 
 	var resp ListResponse
 	if err := c.do(req, &resp); err != nil {
-		return nil, fmt.Errorf("do request: %w", err)
+		return nil, fmt.Errorf("execute request: %w", err)
 	}
 
 	return &resp, nil

--- a/hubspot/list.go
+++ b/hubspot/list.go
@@ -120,12 +120,13 @@ var ResourcesListPaths = map[string]string{
 
 // ListOptions holds optional params for the [List] method.
 type ListOptions struct {
-	Limit        int        `url:"limit,omitempty"`
-	After        string     `url:"after,omitempty"`
-	CreatedAfter *time.Time `url:"createdAfter,omitempty" layout:"2006-01-02T15:04:05.000Z"`
-	UpdatedAfter *time.Time `url:"updatedAfter,omitempty" layout:"2006-01-02T15:04:05.000Z"`
-	Sort         string     `url:"sort,omitempty"`
-	Archived     bool       `url:"archived,omitempty"`
+	Limit         int        `url:"limit,omitempty"`
+	After         string     `url:"after,omitempty"`
+	CreatedAfter  *time.Time `url:"createdAfter,omitempty" layout:"2006-01-02T15:04:05.000Z"`
+	UpdatedAfter  *time.Time `url:"updatedAfter,omitempty" layout:"2006-01-02T15:04:05.000Z"`
+	CreatedBefore *time.Time `url:"createdBefore,omitempty" layout:"2006-01-02T15:04:05.000Z"`
+	Sort          string     `url:"sort,omitempty"`
+	Archived      bool       `url:"archived,omitempty"`
 }
 
 // ListResponse is a common response model for endpoints that returns a list of results.
@@ -184,6 +185,22 @@ func (c *Client) List(ctx context.Context, resource string, opts *ListOptions) (
 	}
 
 	req, err := c.newRequest(ctx, http.MethodGet, resourcePath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create new request: %w", err)
+	}
+
+	var resp ListResponse
+	if err := c.do(req, &resp); err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// ListByNextLink retrieves a list of items by a next link.
+// It doesn't require specifying filters and resources manually.
+func (c *Client) ListByNextLink(ctx context.Context, nextLink string) (*ListResponse, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, nextLink, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create new request: %w", err)
 	}

--- a/hubspot/list.go
+++ b/hubspot/list.go
@@ -28,9 +28,6 @@ const (
 	ResultsFieldCreatedAt string = "createdAt"
 )
 
-// UpdatedAtListSortKey is used as a value for the sort list option.
-const UpdatedAtListSortKey = "updatedAt"
-
 // TimestampResource holds a createdAt, and updatedAt field names.
 type TimestampResource struct {
 	CreatedAtFieldName string
@@ -139,6 +136,43 @@ type ListResponse struct {
 
 // ListResponseResult is a result object for the [ListResponse].
 type ListResponseResult map[string]any
+
+// GetCreatedAt returns the item's createdAt field value.
+func (r ListResponseResult) GetCreatedAt(resource string) (time.Time, error) {
+	if resource, ok := TimestampResources[resource]; ok {
+		return r.GetTimeField(resource.CreatedAtFieldName)
+	}
+
+	if resource, ok := SearchResources[resource]; ok {
+		return r.GetTimeField(resource.CreatedAtFieldName)
+	}
+
+	return time.Time{}, nil
+}
+
+// GetUpdatedAt returns the item's updatedAt field value.
+func (r ListResponseResult) GetUpdatedAt(resource string) (time.Time, error) {
+	if resource, ok := TimestampResources[resource]; ok {
+		return r.GetTimeField(resource.UpdatedAtFieldName)
+	}
+
+	if resource, ok := SearchResources[resource]; ok {
+		return r.GetTimeField(resource.UpdatedAtFieldName)
+	}
+
+	return time.Time{}, nil
+}
+
+// GetDeletedAt returns the item's deletedAt field value.
+func (r ListResponseResult) GetDeletedAt(resource string) (time.Time, error) {
+	if resource, ok := TimestampResources[resource]; ok {
+		if resource.DeletedAtFieldName != "" {
+			return r.GetTimeField(resource.DeletedAtFieldName)
+		}
+	}
+
+	return time.Time{}, nil
+}
 
 // GetTimeField returns a field by a provided field name and parses it into time.Time.
 func (r ListResponseResult) GetTimeField(name string) (time.Time, error) {

--- a/hubspot/list.go
+++ b/hubspot/list.go
@@ -65,6 +65,14 @@ var TimestampResources = map[string]TimestampResource{
 		UpdatedAtFieldName: "updatedAt",
 		DeletedAtFieldName: "deletedAt",
 	},
+	"cms.hubdb.tables": {
+		CreatedAtFieldName: "createdAt",
+		UpdatedAtFieldName: "updatedAt",
+	},
+	"cms.urlRedirects": {
+		CreatedAtFieldName: "createdAt",
+		UpdatedAtFieldName: "updatedAt",
+	},
 }
 
 // ResourcesListPaths holds a mapping of supported resources and their list endpoints.
@@ -80,15 +88,8 @@ var ResourcesListPaths = map[string]string{
 	"cms.pages.site":    "/cms/v3/pages/site-pages",
 	// https://developers.hubspot.com/docs/api/cms/hubdb
 	"cms.hubdb.tables": "/cms/v3/hubdb/tables",
-	// https://developers.hubspot.com/docs/api/cms/domains
-	"cms.domains": "/cms/v3/domains",
 	// https://developers.hubspot.com/docs/api/cms/url-redirects
 	"cms.urlRedirects": "/cms/v3/url-redirects",
-	// https://developers.hubspot.com/docs/api/conversations/conversations
-	"conversations.channels":        "/conversations/v3/conversations/channels",
-	"conversations.channelAccounts": "/conversations/v3/conversations/channel-accounts",
-	"conversations.inboxes":         "/conversations/v3/conversations/inboxes",
-	"conversations.threads":         "/conversations/v3/conversations/threads",
 	// https://developers.hubspot.com/docs/api/crm/companies
 	"crm.companies": "/crm/v3/objects/companies",
 	// https://developers.hubspot.com/docs/api/crm/contacts
@@ -115,16 +116,6 @@ var ResourcesListPaths = map[string]string{
 	"crm.notes": "/crm/v3/objects/notes",
 	// https://developers.hubspot.com/docs/api/crm/tasks
 	"crm.tasks": "/crm/v3/objects/tasks",
-	// https://developers.hubspot.com/docs/api/crm/imports
-	"crm.imports": "/crm/v3/imports",
-	// https://developers.hubspot.com/docs/api/crm/owners
-	"crm.owners": "/crm/v3/owners",
-	// https://developers.hubspot.com/docs/api/events/web-analytics
-	"events.web": "/events/v3/events",
-	// https://developers.hubspot.com/docs/api/marketing/forms
-	"marketing.forms": "/marketing/v3/forms",
-	// https://developers.hubspot.com/docs/api/settings/user-provisioning
-	"settings.users": "/settings/v3/users",
 }
 
 // ListOptions holds optional params for the [List] method.

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -22,8 +22,12 @@ import (
 	"time"
 )
 
-// gteOperator is a greater then operator for search endpoints.
-const gteOperator = "GTE"
+const (
+	// gteOperator is a greater then or equal to operator for search endpoints.
+	gteOperator = "GTE"
+	// lteOperator is a less then or equal to operator for search endpoints.
+	lteOperator = "LTE"
+)
 
 // ascSortDirection stands for ascending sorting order.
 const ascSortDirection = "ASCENDING"
@@ -33,7 +37,9 @@ type SearchResource struct {
 	Path               string
 	CreatedAtFieldName string
 	UpdatedAtFieldName string
+	CreatedAtSortName  string
 	UpdatedAtSortName  string
+	ObjectIDFilterName string
 }
 
 // SearchResources holds a mapping of resources that have search endpoints.
@@ -43,91 +49,117 @@ var SearchResources = map[string]SearchResource{
 		Path:               "/crm/v3/objects/companies/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/contacts
 	"crm.contacts": {
 		Path:               "/crm/v3/objects/contacts/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "createdate",
 		UpdatedAtSortName:  "lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/deals
 	"crm.deals": {
 		Path:               "/crm/v3/objects/deals/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/feedback-submissions
 	"crm.feedbackSubmissions": {
 		Path:               "/crm/v3/objects/feedback_submissions/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "hs_createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/line-items
 	"crm.lineItems": {
 		Path:               "/crm/v3/objects/line_items/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/products
 	"crm.products": {
 		Path:               "/crm/v3/objects/products/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/tickets
 	"crm.tickets": {
 		Path:               "/crm/v3/objects/tickets/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/quotes
 	"crm.quotes": {
 		Path:               "/crm/v3/objects/quotes/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "hs_createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/calls
 	"crm.calls": {
 		Path:               "/crm/v3/objects/calls/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "hs_createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/email
 	"crm.emails": {
 		Path:               "/crm/v3/objects/emails/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "hs_createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/meetings
 	"crm.meetings": {
 		Path:               "/crm/v3/objects/meetings/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "hs_createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/notes
 	"crm.notes": {
 		Path:               "/crm/v3/objects/notes/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "hs_createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 	// https://developers.hubspot.com/docs/api/crm/tasks
 	"crm.tasks": {
 		Path:               "/crm/v3/objects/tasks/search",
 		CreatedAtFieldName: "createdAt",
 		UpdatedAtFieldName: "updatedAt",
+		CreatedAtSortName:  "hs_createdate",
 		UpdatedAtSortName:  "hs_lastmodifieddate",
+		ObjectIDFilterName: "hs_object_id",
 	},
 }
 
@@ -213,4 +245,61 @@ func (c *Client) SearchByUpdatedAfter(
 			},
 		},
 	})
+}
+
+// SearchByCreatedBefore is a wrapper that calls the [Search] method returning only those results
+// that were created before a specific date and ordering them ascendingly by createdAt field.
+func (c *Client) SearchByCreatedBefore(
+	ctx context.Context,
+	resource string,
+	createdBefore time.Time,
+	limit int,
+	after int,
+) (*ListResponse, error) {
+	searchResource, ok := SearchResources[resource]
+	if !ok {
+		return nil, &UnsupportedResourceError{
+			Resource: resource,
+		}
+	}
+
+	// create filters based on a provided arguments
+	filters := []SearchRequestFilterGroupFilter{
+		{
+			PropertyName: searchResource.CreatedAtSortName,
+			Operator:     lteOperator,
+			Value:        strconv.Itoa(int(createdBefore.UnixMilli())),
+		},
+	}
+
+	if after != 0 {
+		filters = append(filters, SearchRequestFilterGroupFilter{
+			PropertyName: searchResource.ObjectIDFilterName,
+			Operator:     gteOperator,
+			Value:        strconv.Itoa(after),
+		})
+	}
+
+	// construct request body with the created filters and sorting
+	req := &SearchRequest{
+		FilterGroups: []SearchRequestFilterGroup{
+			{
+				Filters: filters,
+			},
+		},
+		Sorts: []SearchRequestSort{
+			{
+				PropertyName: searchResource.CreatedAtSortName,
+				Direction:    ascSortDirection,
+			},
+		},
+	}
+
+	// we'll use the limit if it's not zero
+	// by default HubSpot set this value to 100
+	if limit != 0 {
+		req.Limit = strconv.Itoa(limit)
+	}
+
+	return c.Search(ctx, resource, req)
 }

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -263,7 +263,7 @@ func (c *Client) SearchByCreatedBefore(
 		}
 	}
 
-	// create filters based on a provided arguments
+	// create filters based on provided arguments
 	filters := []SearchRequestFilterGroupFilter{
 		{
 			PropertyName: searchResource.CreatedAtSortName,

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -204,7 +204,7 @@ func (c *Client) Search(ctx context.Context, resource string, request *SearchReq
 
 	var resp ListResponse
 	if err := c.do(req, &resp); err != nil {
-		return nil, fmt.Errorf("do request: %w", err)
+		return nil, fmt.Errorf("execute request: %w", err)
 	}
 
 	return &resp, nil

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -253,8 +253,7 @@ func (c *Client) SearchByCreatedBefore(
 	ctx context.Context,
 	resource string,
 	createdBefore time.Time,
-	limit int,
-	after int,
+	limit, after int,
 ) (*ListResponse, error) {
 	searchResource, ok := SearchResources[resource]
 	if !ok {

--- a/source/iterator/cdc.go
+++ b/source/iterator/cdc.go
@@ -154,7 +154,7 @@ func (c *CDC) fetchTimestampBasedItems(
 	listOpts := &hubspot.ListOptions{
 		Limit:        c.bufferSize,
 		UpdatedAfter: &updatedAfter,
-		Sort:         hubspot.UpdatedAtListSortKey,
+		Sort:         resource.UpdatedAtFieldName,
 		Archived:     true,
 	}
 

--- a/source/iterator/cdc.go
+++ b/source/iterator/cdc.go
@@ -20,9 +20,8 @@ import (
 	"strconv"
 	"time"
 
-	sdk "github.com/conduitio/conduit-connector-sdk"
-
 	"github.com/conduitio-labs/conduit-connector-hubspot/hubspot"
+	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
 // CDC is an implementation of a CDC iterator for the HubSpot API.

--- a/source/iterator/cdc.go
+++ b/source/iterator/cdc.go
@@ -159,12 +159,12 @@ func (c *CDC) fetchTimestampBasedItems(
 		Archived:     true,
 	}
 
-	listResp, err := c.hubspotClient.List(ctx, c.resource, listOpts)
+	listResponse, err := c.hubspotClient.List(ctx, c.resource, listOpts)
 	if err != nil {
 		return fmt.Errorf("list items: %w", err)
 	}
 
-	for _, item := range listResp.Results {
+	for _, item := range listResponse.Results {
 		err = c.routeItem(item,
 			resource.CreatedAtFieldName,
 			resource.UpdatedAtFieldName,
@@ -185,12 +185,12 @@ func (c *CDC) fetchSearchBasedItems(
 	resource hubspot.SearchResource,
 	updatedAfter time.Time,
 ) error {
-	listResp, err := c.hubspotClient.SearchByUpdatedAfter(ctx, c.resource, updatedAfter, c.bufferSize)
+	listResponse, err := c.hubspotClient.SearchByUpdatedAfter(ctx, c.resource, updatedAfter, c.bufferSize)
 	if err != nil {
 		return fmt.Errorf("list items: %w", err)
 	}
 
-	for _, item := range listResp.Results {
+	for _, item := range listResponse.Results {
 		err = c.routeItem(item, resource.CreatedAtFieldName, resource.UpdatedAtFieldName, "", updatedAfter)
 		if err != nil {
 			return fmt.Errorf("route search based item: %w", err)

--- a/source/iterator/combined.go
+++ b/source/iterator/combined.go
@@ -83,7 +83,7 @@ func (c *Combined) HasNext(ctx context.Context) (bool, error) {
 			return false, fmt.Errorf("snapshot has next: %w", err)
 		}
 
-		if !hasNext && c.isCDCSupported() {
+		if !hasNext {
 			sdk.Logger(ctx).Debug().Msgf("switching to the CDC mode")
 
 			if err := c.switchToCDCIterator(ctx); err != nil {
@@ -115,19 +115,6 @@ func (c *Combined) Next(ctx context.Context) (sdk.Record, error) {
 	default:
 		return sdk.Record{}, ErrNoInitializedIterator
 	}
-}
-
-// isCDCSupported checks whether the iterator's resource supports CDC or not.
-func (c *Combined) isCDCSupported() bool {
-	if _, ok := hubspot.TimestampResources[c.resource]; ok {
-		return true
-	}
-
-	if _, ok := hubspot.SearchResources[c.resource]; ok {
-		return true
-	}
-
-	return false
 }
 
 // switchToCDCIterator initializes the cdc iterator, and set the snapshot to nil.

--- a/source/iterator/position.go
+++ b/source/iterator/position.go
@@ -67,3 +67,19 @@ func ParsePosition(sdkPosition sdk.Position) (*Position, error) {
 
 	return &position, nil
 }
+
+// ConvertToCDCPosition converts a provided [sdk.Position] into the [Position],
+// updates its Mode to [CDCPositionMode] and marshals it back to the [sdk.Position].
+func ConvertToCDCPosition(sdkPosition sdk.Position) (sdk.Position, error) {
+	position, err := ParsePosition(sdkPosition)
+	if err != nil {
+		return sdk.Position{}, err
+	}
+
+	position.Mode = CDCPositionMode
+
+	now := time.Now().UTC()
+	position.Timestamp = &now
+
+	return position.MarshalSDKPosition()
+}

--- a/source/iterator/position.go
+++ b/source/iterator/position.go
@@ -39,6 +39,8 @@ type Position struct {
 	Mode PositionMode `json:"mode"`
 	// ItemID is used if the position's mode is [SnapshotPositionMode].
 	ItemID int `json:"itemId,omitempty"`
+	// InitialTimestamp is an initial timestamp of a snapshot.
+	InitialTimestamp *time.Time `json:"initialTimestamp,omitempty"`
 	// Timestamp is used if the position's mode is [CDCPositionMode].
 	Timestamp *time.Time `json:"timestamp,omitempty"`
 }

--- a/source/iterator/position.go
+++ b/source/iterator/position.go
@@ -69,19 +69,3 @@ func ParsePosition(sdkPosition sdk.Position) (*Position, error) {
 
 	return &position, nil
 }
-
-// ConvertToCDCPosition converts a provided [sdk.Position] into the [Position],
-// updates its Mode to [CDCPositionMode] and marshals it back to the [sdk.Position].
-func ConvertToCDCPosition(sdkPosition sdk.Position) (sdk.Position, error) {
-	position, err := ParsePosition(sdkPosition)
-	if err != nil {
-		return sdk.Position{}, err
-	}
-
-	position.Mode = CDCPositionMode
-
-	now := time.Now().UTC()
-	position.Timestamp = &now
-
-	return position.MarshalSDKPosition()
-}

--- a/source/iterator/snapshot.go
+++ b/source/iterator/snapshot.go
@@ -166,8 +166,8 @@ func (s *Snapshot) loadRecords(ctx context.Context) error {
 // listItems returns items depending on what resource it is.
 // It supports both timestamp- and search-based resources.
 func (s *Snapshot) listItems(ctx context.Context) (*hubspot.ListResponse, error) {
-	if _, ok := hubspot.TimestampResources[s.resource]; ok {
-		return s.listTimestampBasedItems(ctx)
+	if resource, ok := hubspot.TimestampResources[s.resource]; ok {
+		return s.listTimestampBasedItems(ctx, resource)
 	}
 
 	if _, ok := hubspot.SearchResources[s.resource]; ok {
@@ -182,7 +182,10 @@ func (s *Snapshot) listItems(ctx context.Context) (*hubspot.ListResponse, error)
 
 // listTimestampBasedItems retrieves timestamp-based items using limit, after and createdBefore query parameters.
 // The createdBefore parameter is equal to the [Snapshot]'s initialTimestamp value.
-func (s *Snapshot) listTimestampBasedItems(ctx context.Context) (*hubspot.ListResponse, error) {
+func (s *Snapshot) listTimestampBasedItems(
+	ctx context.Context,
+	resource hubspot.TimestampResource,
+) (*hubspot.ListResponse, error) {
 	if s.nextLink != "" {
 		listResponse, err := s.hubspotClient.ListByNextLink(ctx, s.nextLink)
 		if err != nil {
@@ -195,6 +198,7 @@ func (s *Snapshot) listTimestampBasedItems(ctx context.Context) (*hubspot.ListRe
 	listOpts := &hubspot.ListOptions{
 		Limit:         s.bufferSize,
 		CreatedBefore: &s.initialTimestamp,
+		Sort:          resource.CreatedAtFieldName,
 	}
 
 	listResponse, err := s.hubspotClient.List(ctx, s.resource, listOpts)

--- a/source/iterator/snapshot.go
+++ b/source/iterator/snapshot.go
@@ -39,7 +39,7 @@ type Snapshot struct {
 	initialTimestamp time.Time
 	// nextLink is used for timestamp-based resources.
 	nextLink string
-	// hasMoreItems is used for search-based resources.
+	// hasMoreItems is used for both timestamp- and search-based resources.
 	hasMoreItems bool
 }
 
@@ -77,7 +77,7 @@ func NewSnapshot(ctx context.Context, params SnapshotParams) (*Snapshot, error) 
 
 // HasNext returns a bool indicating whether the iterator has the next record to return or not.
 func (s *Snapshot) HasNext(ctx context.Context) (bool, error) {
-	return len(s.records) > 0 || s.nextLink != "" || s.hasMoreItems, nil
+	return len(s.records) > 0 || s.hasMoreItems, nil
 }
 
 // Next returns the next record.

--- a/source/iterator/snapshot.go
+++ b/source/iterator/snapshot.go
@@ -94,6 +94,11 @@ func (s *Snapshot) Next(ctx context.Context) (sdk.Record, error) {
 	}
 }
 
+// Stop stops the iterator.
+func (s *Snapshot) Stop() {
+	s.stopC <- struct{}{}
+}
+
 // poll polls items at the specified time intervals.
 func (s *Snapshot) poll(ctx context.Context) {
 	ticker := time.NewTicker(s.pollingPeriod)
@@ -255,9 +260,4 @@ func (s *Snapshot) getItemMetadata(item map[string]any) (metadata sdk.Metadata, 
 	metadata.SetCreatedAt(createdAt)
 
 	return metadata, nil
-}
-
-// Stop stops the iterator.
-func (s *Snapshot) Stop() {
-	s.stopC <- struct{}{}
 }


### PR DESCRIPTION
### Description

This PR seeks to remove HubSpot resources that don't support CDC and fix `bufferSize` and HubSpot limit functionality.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-hubspot/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
