### PR TITLE
Add Destination documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,20 @@ Here's an example of a CDC position:
 ### Known limitations
 
 - Not all resources support all CDC operations. You can check the available resources and operations they support out [here](docs/resources.md).
+
+## Destination
+
+The HubSpot Destination takes a `record.Record` and sends its payload to HubSpot without any transformations. The destination is designed to handle different payloads. You can check the available resources and operations they support out [here](/docs/resources.md).
+
+### Configuration options
+
+| name            | description                                                                                                                            | required | default |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| `accessToken`   | The private app access token for accessing the HubSpot API.                                                                            | **true** |         |
+| `resource`      | The HubSpot resource that the connector will work with.<br />You can find a list of the available resources [here](docs/resources.md). | **true** |         |
+| `maxRetries`    | The number of HubSpot API request retries attempts that will be tried before giving up if a request fails.                             | false    | `4`     |
+
+### Known limitations
+
+- To perform the update or delete operations the destination requires the `record.Key` to be set.
+- If you want to use the destination to insert records from a source containing records that were previously taken by the HubSpot source, you may need to exclude some read-only fields from their payload. When trying to insert read-only fields you'll see an appropriate error message in the logs containing the names of the read-only fields.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,4 +1,4 @@
-Here you can find a list of the available HubSpot resources and operations they support.
+Here you can find a list of the available HubSpot resources and operations they can track (source) and perform (destination).
 
 | resource                                                                                      | source operations                        | destination operations       |
 | --------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------- |

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,24 +1,24 @@
 Here you can find a list of the available HubSpot resources and operations they support.
 
-| resource                                                                                      | source operations                        |
-| --------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| [`cms.blogs.authors`](https://developers.hubspot.com/docs/api/cms/blog-authors)               | `snapshot`, `insert`, `update`, `delete` |
-| [`cms.blogs.posts`](https://developers.hubspot.com/docs/api/cms/blog-post)                    | `snapshot`, `insert`, `update`, `delete` |
-| [`cms.blogs.tags`](https://developers.hubspot.com/docs/api/cms/blog-tags)                     | `snapshot`, `insert`, `update`, `delete` |
-| [`cms.pages.landing`](https://developers.hubspot.com/docs/api/cms/pages)                      | `snapshot`, `insert`, `update`, `delete` |
-| [`cms.pages.site`](https://developers.hubspot.com/docs/api/cms/pages)                         | `snapshot`, `insert`, `update`, `delete` |
-| [`cms.hubdb.tables`](https://developers.hubspot.com/docs/api/cms/hubdb)                       | `snapshot`, `insert`, `update`           |
-| [`cms.urlRedirects`](https://developers.hubspot.com/docs/api/cms/url-redirects)               | `snapshot`, `insert`, `update`           |
-| [`crm.companies`](https://developers.hubspot.com/docs/api/crm/companies)                      | `snapshot`, `insert`, `update`           |
-| [`crm.contacts`](https://developers.hubspot.com/docs/api/crm/contacts)                        | `snapshot`, `insert`, `update`           |
-| [`crm.deals`](https://developers.hubspot.com/docs/api/crm/deals)                              | `snapshot`, `insert`, `update`           |
-| [`crm.feedbackSubmissions`](https://developers.hubspot.com/docs/api/crm/feedback-submissions) | `snapshot`, `insert`, `update`           |
-| [`crm.lineItems`](https://developers.hubspot.com/docs/api/crm/line-items)                     | `snapshot`, `insert`, `update`           |
-| [`crm.products`](https://developers.hubspot.com/docs/api/crm/products)                        | `snapshot`, `insert`, `update`           |
-| [`crm.tickets`](https://developers.hubspot.com/docs/api/crm/tickets)                          | `snapshot`, `insert`, `update`           |
-| [`crm.quotes`](https://developers.hubspot.com/docs/api/crm/quotes)                            | `snapshot`, `insert`, `update`           |
-| [`crm.calls`](https://developers.hubspot.com/docs/api/crm/calls)                              | `snapshot`, `insert`, `update`           |
-| [`crm.emails`](https://developers.hubspot.com/docs/api/crm/email)                             | `snapshot`, `insert`, `update`           |
-| [`crm.meetings`](https://developers.hubspot.com/docs/api/crm/meetings)                        | `snapshot`, `insert`, `update`           |
-| [`crm.notes`](https://developers.hubspot.com/docs/api/crm/notes)                              | `snapshot`, `insert`, `update`           |
-| [`crm.tasks`](https://developers.hubspot.com/docs/api/crm/tasks)                              | `snapshot`, `insert`, `update`           |
+| resource                                                                                      | source operations                        | destination operations       |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------- |
+| [`cms.blogs.authors`](https://developers.hubspot.com/docs/api/cms/blog-authors)               | `snapshot`, `insert`, `update`, `delete` | `create`, `update`, `delete` |
+| [`cms.blogs.posts`](https://developers.hubspot.com/docs/api/cms/blog-post)                    | `snapshot`, `insert`, `update`, `delete` | `create`, `update`, `delete` |
+| [`cms.blogs.tags`](https://developers.hubspot.com/docs/api/cms/blog-tags)                     | `snapshot`, `insert`, `update`, `delete` | `create`, `update`, `delete` |
+| [`cms.pages.landing`](https://developers.hubspot.com/docs/api/cms/pages)                      | `snapshot`, `insert`, `update`, `delete` | `create`, `update`, `delete` |
+| [`cms.pages.site`](https://developers.hubspot.com/docs/api/cms/pages)                         | `snapshot`, `insert`, `update`, `delete` | `create`, `update`, `delete` |
+| [`cms.hubdb.tables`](https://developers.hubspot.com/docs/api/cms/hubdb)                       | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`cms.urlRedirects`](https://developers.hubspot.com/docs/api/cms/url-redirects)               | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.companies`](https://developers.hubspot.com/docs/api/crm/companies)                      | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.contacts`](https://developers.hubspot.com/docs/api/crm/contacts)                        | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.deals`](https://developers.hubspot.com/docs/api/crm/deals)                              | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.feedbackSubmissions`](https://developers.hubspot.com/docs/api/crm/feedback-submissions) | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.lineItems`](https://developers.hubspot.com/docs/api/crm/line-items)                     | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.products`](https://developers.hubspot.com/docs/api/crm/products)                        | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.tickets`](https://developers.hubspot.com/docs/api/crm/tickets)                          | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.quotes`](https://developers.hubspot.com/docs/api/crm/quotes)                            | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.calls`](https://developers.hubspot.com/docs/api/crm/calls)                              | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.emails`](https://developers.hubspot.com/docs/api/crm/email)                             | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.meetings`](https://developers.hubspot.com/docs/api/crm/meetings)                        | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.notes`](https://developers.hubspot.com/docs/api/crm/notes)                              | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |
+| [`crm.tasks`](https://developers.hubspot.com/docs/api/crm/tasks)                              | `snapshot`, `insert`, `update`           | `create`, `update`, `delete` |


### PR DESCRIPTION
### Description

This PR seeks to add Destination documentation and a list of destination operations that resources support.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-hubspot/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
