### PR TITLE
Make `Position.ItemID` a string

### DIFF
--- a/source/iterator/cdc.go
+++ b/source/iterator/cdc.go
@@ -17,7 +17,6 @@ package iterator
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/conduitio-labs/conduit-connector-hubspot/hubspot"
@@ -288,15 +287,10 @@ func (c *CDC) getRecord(item hubspot.ListResponseResult,
 
 // getItemPosition grabs an id field from a provided item and constructs a [Position] based on its value.
 func (c *CDC) getItemPosition(item map[string]any, timestamp time.Time) (*Position, error) {
-	itemIDStr, ok := item[hubspot.ResultsFieldID].(string)
+	itemID, ok := item[hubspot.ResultsFieldID].(string)
 	if !ok {
 		// this shouldn't happen cause HubSpot API v3 returns items with string identifiers.
 		return nil, ErrItemIDIsNotAString
-	}
-
-	itemID, err := strconv.Atoi(itemIDStr)
-	if err != nil {
-		return nil, fmt.Errorf("convert item's id string to integer: %w", err)
 	}
 
 	return &Position{

--- a/source/iterator/position.go
+++ b/source/iterator/position.go
@@ -38,7 +38,7 @@ const (
 type Position struct {
 	Mode PositionMode `json:"mode"`
 	// ItemID is used if the position's mode is [SnapshotPositionMode].
-	ItemID int `json:"itemId,omitempty"`
+	ItemID string `json:"itemId,omitempty"`
 	// InitialTimestamp is an initial timestamp of a snapshot.
 	InitialTimestamp *time.Time `json:"initialTimestamp,omitempty"`
 	// Timestamp is used if the position's mode is [CDCPositionMode], or for [SnapshotPositionMode] if it was interrupted.

--- a/source/iterator/position_test.go
+++ b/source/iterator/position_test.go
@@ -26,7 +26,7 @@ func TestPosition_MarshalSDKPosition(t *testing.T) {
 
 	type fields struct {
 		Mode   PositionMode
-		LastID int
+		LastID string
 	}
 
 	tests := []struct {
@@ -39,9 +39,9 @@ func TestPosition_MarshalSDKPosition(t *testing.T) {
 			name: "success",
 			fields: fields{
 				Mode:   CDCPositionMode,
-				LastID: 1,
+				LastID: "1",
 			},
-			want:    sdk.Position([]byte(`{"mode":"cdc","itemId":1}`)),
+			want:    sdk.Position([]byte(`{"mode":"cdc","itemId":"1"}`)),
 			wantErr: false,
 		},
 	}
@@ -87,11 +87,11 @@ func TestParsePosition(t *testing.T) {
 		{
 			name: "success",
 			args: args{
-				sdkPosition: sdk.Position([]byte(`{"mode":"cdc","itemId": 1}`)),
+				sdkPosition: sdk.Position([]byte(`{"mode":"cdc","itemId": "1"}`)),
 			},
 			want: &Position{
 				Mode:   CDCPositionMode,
-				ItemID: 1,
+				ItemID: "1",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
### Description

This PR seeks to make `Position.ItemID` a string.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-hubspot/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
